### PR TITLE
Fix issues with python 3

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,9 +1,0 @@
-[flake8]
-ignore = E501  # Line length < 80
-exclude =
-    .git,
-    __pycache__,
-    build,
-    dist,
-    venv
-

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -25,12 +25,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 pytest
         pip install .
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
         rm -r komodoenv  # Remove sources

--- a/komodoenv/context.py
+++ b/komodoenv/context.py
@@ -26,12 +26,12 @@ class Context(object):
             return
 
         # Get python version_info
-        script = "import sys,json;print(json.dumps(sys.version_info[:]))"
+        script = b"import sys,json;print(json.dumps(sys.version_info[:]))"
         env = {"LD_LIBRARY_PATH": "{0}/lib:{0}/lib64".format(self.srcpath / "root")}
         self.version_info = json.loads(self.invoke_srcpython(script=script, env=env))
 
         # Get python sys.path
-        script = "import sys,json;print(json.dumps(sys.path))"
+        script = b"import sys,json;print(json.dumps(sys.path))"
         env = {"LD_LIBRARY_PATH": "{0}/lib:{0}/lib64".format(self.srcpath / "root")}
         self.src_python_paths = json.loads(
             self.invoke_srcpython(script=script, env=env)

--- a/komodoenv/creator.py
+++ b/komodoenv/creator.py
@@ -89,24 +89,26 @@ def create_enable_scripts(ctx):
 
 
 def create_virtualenv(ctx):
-    env = os.environ.copy()
-    env["LD_LIBRARY_PATH"] = str(ctx.srcpath / "root" / "lib")
-
     tmpdir = mkdtemp(prefix="komodoenv.")
-    print(
-        subprocess.check_output(
-            [
-                "virtualenv",
-                "--python",
-                str(ctx.src_python_path),
-                "--app-data",
-                tmpdir,
-                "--always-copy",
-                str(ctx.dstpath / "root"),
-            ],
-            env=env,
-        )
+
+    from virtualenv import cli_run
+
+    ld_library_path = os.environ.get("LD_LIBRARY_PATH")
+    os.environ["LD_LIBRARY_PATH"] = str(ctx.srcpath / "root" / "lib")
+    cli_run(
+        [
+            "--python",
+            str(ctx.src_python_path),
+            "--app-data",
+            tmpdir,
+            "--always-copy",
+            str(ctx.dstpath / "root"),
+        ],
     )
+    if ld_library_path is None:
+        del os.environ["LD_LIBRARY_PATH"]
+    else:
+        os.environ["LD_LIBRARY_PATH"] = ld_library_path
 
 
 def copy_update_script(ctx):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,4 +1,5 @@
 import sys
+from six import ensure_binary
 from komodoenv.context import Context
 
 
@@ -6,15 +7,15 @@ def test_invoke_python():
     ctx = Context("/usr")
 
     out = ctx.invoke_python(sys.executable, ["-c", "print('Test')"])
-    assert out == "Test\n"
+    assert out == b"Test\n"
 
 
 def test_invoke_python_script():
     ctx = Context("/usr")
-    script = "import sys;print(sys.executable)"
+    script = b"import sys;print(sys.executable)"
 
     out = ctx.invoke_python(sys.executable, script=script)
-    assert out == "{}\n".format(sys.executable)
+    assert out == ensure_binary("{}\n".format(sys.executable))
 
 
 def test_invoke_srcpython_script():

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,6 +1,7 @@
 from komodoenv import update
 from textwrap import dedent
 import time
+import six
 
 
 def test_rewrite_executable_python():
@@ -22,8 +23,10 @@ def test_rewrite_executable_python():
     lines = pip.splitlines()
     lines[0] = "#!" + python
 
-    actual = update.rewrite_executable("/prog/res/komodo/bin/pip", python, pip)
-    assert "\n".join(lines) == actual
+    actual = update.rewrite_executable(
+        "/prog/res/komodo/bin/pip", python, six.ensure_binary(pip)
+    )
+    assert six.ensure_binary("\n".join(lines)) == actual
 
 
 def test_rewrite_executable_binary():
@@ -39,7 +42,9 @@ def test_rewrite_executable_binary():
     """
     )
 
-    assert expect == update.rewrite_executable("/prog/res/komodo/bin/bash", python, sh)
+    assert six.ensure_binary(expect) == update.rewrite_executable(
+        "/prog/res/komodo/bin/bash", python, six.ensure_binary(sh)
+    )
 
 
 def test_rewrite_executable_other_shebang():
@@ -80,7 +85,9 @@ def test_rewrite_executable_other_shebang():
     """
     )
 
-    assert expect == update.rewrite_executable("/prog/res/komodo/bin/gem", python, gem)
+    assert six.ensure_binary(expect) == update.rewrite_executable(
+        "/prog/res/komodo/bin/gem", python, six.ensure_binary(gem)
+    )
 
 
 def test_track(tmpdir):


### PR DESCRIPTION
- Most of the issues were str/bytes
- Removed flake8 because it was annoying
- Use virtualenv's `cli_run` function, which I don't think has stable API, but works better than running the shell tool.