### PR TITLE
Piggyback on komodo's enable's envvars

### DIFF
--- a/komodoenv/creator.py
+++ b/komodoenv/creator.py
@@ -32,8 +32,6 @@ disable_komodo () {{
         hash -r
     fi
 
-    unset KOMODOENV_PREFIX
-    unset KOMODOENV_RELEASE
     unset KOMODO_RELEASE
     unset ERT_LSF_SERVER
 
@@ -45,23 +43,21 @@ disable_komodo () {{
 # unset irrelevant variables
 disable_komodo preserve_disable_komodo
 
-export KOMODOENV_PREFIX={komodoenv_prefix}
-export KOMODOENV_RELEASE={komodoenv_release}
-export KOMODO_RELEASE={komodo_release}
+export KOMODO_RELEASE={komodoenv_prefix}
 
 export _PRE_KOMODO_PATH="$PATH"
-export PATH={komodoenv_prefix}/bin:{komodoenv_prefix}/shims:{komodo_prefix}/bin${{PATH:+:${{PATH}}}}
+export PATH={komodoenv_prefix}/root/bin:{komodoenv_prefix}/root/shims${{PATH:+:${{PATH}}}}
 
 export _PRE_KOMODO_MANPATH="$MANPATH"
-export MANPATH={komodoenv_prefix}/share/man:{komodo_prefix}/share/man:${{MANPATH}}
+export MANPATH={komodoenv_prefix}/root/share/man:{komodo_prefix}/root/share/man${{MANPATH:+:${{MANPATH}}}}
 
 export _PRE_KOMODO_LD_LIBRARY_PATH="$LD_LIBRARY_PATH"
 unset LD_LIBRARY_PATH
 
 export _PRE_KOMODO_PS1="${{PS1:-}}"
-export PS1="(${{KOMODOENV_RELEASE}} + ${{KOMODO_RELEASE}}) ${{PS1}}"
+export PS1="({komodoenv_release} + {komodo_release}) ${{PS1:-}}"
 
-local_script="{komodo_prefix}/../local"
+local_script="{komodo_prefix}/local"
 if [ -e "$local_script" ]; then
     source "$local_script"
 fi
@@ -74,9 +70,9 @@ fi
 
 def generate_enable_script(ctx, fmt):
     return fmt.format(
-        komodo_prefix=(ctx.srcpath / "root"),
+        komodo_prefix=ctx.srcpath,
         komodo_release=ctx.srcpath.name,
-        komodoenv_prefix=(ctx.dstpath / "root"),
+        komodoenv_prefix=ctx.dstpath,
         komodoenv_release=ctx.dstpath.name,
     )
 

--- a/tests/test_creator.py
+++ b/tests/test_creator.py
@@ -24,9 +24,9 @@ def test_generate_enable_script():
 
     expect = dedent(
         """\
-    /prog/res/komodo/stable/root
+    /prog/res/komodo/stable
     stable
-    /private/unittest/kenv/root
+    /private/unittest/kenv
     kenv
     """
     )


### PR DESCRIPTION
We were setting a custom `KOMODOENV_PREFIX` variable. Instead, following path of
least resistance, we'll only use variables that komodo itself sets. Thus,
`KOMODO_RELEASE` was previously the name of the release (eg. `2020.03.01-py27`)

With this, we set `KOMODO_RELEASE` to be the full path to the user's komodoenv.
`komodo_job_dispatch` is the biggest consumer of this, and it was doing the
incorrect thing to begin with.

Thus, after this change, we won't be able to know which komodo release this
komodoenv was based on as easily, however, this might be fine. There are other
ways to tell (read the generated `komodoenv.conf`)

Then, if `KOMODO_RELEASE` doesn't have a `/`, it's a vanilla komodo release from
`/prog/res/komodo`. If `KOMODO_RELEASE` is an absolute path (contains a `/` as
its first character), then it's the path to a komodoenv. Otherwise, relative
paths make no sense here.