### PR TITLE
Detect RHEL version

### DIFF
--- a/komodoenv/update.py
+++ b/komodoenv/update.py
@@ -249,10 +249,13 @@ def get_pkg_version(config, srcpath, package="komodoenv"):
     )
     pattern = re.compile("^{}-(.+).dist-info".format(package))
 
+    matches = []
     for name in os.listdir(pkgdir):
         match = pattern.match(name)
         if match is not None:
-            return match[1]
+            matches.append(match[1])
+    if len(matches) > 0:
+        return max(matches)
 
 
 def can_update(config):

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     test_suite="tests",
     install_requires=[
         "ansicolors",
+        "distro",
         "PyYAML",
         "enum34;python_version < '3.4'",
         "mock;python_version < '3.3'",


### PR DESCRIPTION
Use the `distro` package to detect and appropriately suffix komodo release path.