### PR TITLE
Have distro_versions return a tuple of strings

### DIFF
--- a/komodoenv/update.py
+++ b/komodoenv/update.py
@@ -23,7 +23,7 @@ except ImportError:
         return "none"
 
     def distro_versions():
-        return (0, 0, 0)
+        return ("0", "0", "0")
 
 
 ENABLE_BASH = """\


### PR DESCRIPTION
`distro`'s `version_parts()` returns a `str`-triplet, not an `int`-triplet, fix it in the fallback dummy code too.