### PR TITLE
Make the default distro rhel7

### DIFF
--- a/komodoenv/update.py
+++ b/komodoenv/update.py
@@ -18,12 +18,14 @@ from textwrap import dedent
 try:
     from distro import id as distro_id, version_parts as distro_versions
 except ImportError:
-
+    # The 'distro' package isn't installed. Pretend we're on RHEL7.
+    #
+    # yum install python36-distro
     def distro_id():
-        return "none"
+        return "rhel"
 
     def distro_versions():
-        return ("0", "0", "0")
+        return ("7", "0", "0")
 
 
 ENABLE_BASH = """\


### PR DESCRIPTION
Machines without the `distro` package are assumed to be RHEL7 since it's the only distro `komodoenv` supports as this moment.