### PR TITLE
Set LD_LIBRARY_PATH in enable scripts

### DIFF
--- a/komodoenv/update.py
+++ b/komodoenv/update.py
@@ -70,7 +70,7 @@ export _PRE_KOMODO_MANPATH="${{MANPATH:-}}"
 export MANPATH={komodoenv_prefix}/root/share/man:{komodo_prefix}/root/share/man${{MANPATH:+:${{MANPATH}}}}
 
 export _PRE_KOMODO_LD_LIBRARY_PATH="${{LD_LIBRARY_PATH:-}}"
-unset LD_LIBRARY_PATH
+export LD_LIBRARY_PATH={komodo_prefix}/root/lib:{komodo_prefix}/lib64${{LD_LIBRARY_PATH:+${{LD_LIBRARY_PATH}}}}
 
 export _PRE_KOMODO_PS1="${{PS1:-}}"
 export PS1="({komodoenv_release} + {komodo_release}) ${{PS1:-}}"
@@ -131,7 +131,9 @@ endif
 
 if $?LD_LIBRARY_PATH then
     setenv _PRE_KOMODO_LD_PATH "$LD_LIBRARY_PATH"
-    unsetenv LD_LIBRARY_PATH
+    setenv LD_LIBRARY_PATH {komodo_prefix}/root/lib:{komodo_prefix}/root/lib64:$LD_LIBRARY_PATH
+else
+    setenv LD_LIBRARY_PATH {komodo_prefix}/root/lib:{komodo_prefix}/root/lib64
 endif
 
 setenv KOMODO_RELEASE {komodoenv_prefix}


### PR DESCRIPTION
`komodoenv` has stopped using executable shimming, so we need to start setting `LD_LIBRARY_PATH` in `enable` again.