### PR TITLE
Add install_extra script for Komodo unit-test use

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     steps:
     - uses: actions/checkout@v2
@@ -25,7 +25,7 @@ jobs:
         sudo apt-get -y install tcsh python3-venv python3.8-venv
     - name: Install Python Packages
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools wheel
         pip install flake8 pytest
         pip install .
     - name: Test with pytest

--- a/komodoenv/scripts/install_extra.py
+++ b/komodoenv/scripts/install_extra.py
@@ -1,0 +1,58 @@
+import argparse
+import sys
+import os
+from typing import List, Optional
+
+import pkg_resources
+
+
+def parse_args(args: List[str]) -> argparse.Namespace:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("package")
+    ap.add_argument("extras", nargs=argparse.REMAINDER)
+    return ap.parse_args(args)
+
+
+def get_requires_for_package(package: str, extras: List[str]) -> List[str]:
+    dist = pkg_resources.get_distribution(package)
+    print(
+        f"The following extras are available for '{dist.project_name}': {', '.join(dist.extras)}",
+        file=sys.stderr,
+    )
+
+    non_extra_pkgs = {x.project_name for x in dist.requires()}
+    pkgs = dist.requires(extras=extras)
+
+    install = []
+    for pkg in pkgs:
+        if pkg.project_name in non_extra_pkgs:
+            continue
+        if pkg.marker and not pkg.marker.evaluate(environment={"extra": True}):
+            continue
+        pkg.marker = None
+        install.append(str(pkg))
+    return install
+
+
+def main(argv: Optional[List[str]] = None):
+    """
+    Usage: install_extra [PACKAGE] [EXTRAS...]
+
+    Install _only_ the extras requires for the specified package, without
+    installing the non-extra dependencies.
+    """
+
+    if argv is None:
+        argv = sys.argv[1:]
+    args = parse_args(argv)
+
+    install = get_requires_for_package(args.package, args.extras)
+    print("--- Installing the following dependencies ---", file=sys.stderr)
+    print("\n".join(install), file=sys.stderr)
+
+    print("--------------- Starting  pip ---------------", file=sys.stderr)
+    os.execv(sys.executable, [sys.executable, "-m", "pip", "install", *install])
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -5,16 +5,36 @@ setup(
     name="komodoenv",
     author="Equinor ASA",
     author_email="fg_sib-scout@equinor.com",
-    packages=["komodoenv", "komodoenv.bundle"],
+    packages=["komodoenv", "komodoenv.bundle", "komodoenv.scripts"],
     package_data={
         "komodoenv": ["bundle/*.whl"],
     },
     test_suite="tests",
     install_requires=[
+        "PyYAML",
         "ansicolors",
         "distro",
-        "PyYAML",
+        "setuptools"  # pkg_resources
     ],
+    extras_require={
+        # These extras are made for unit testing of komodoenv, not to be
+        # installed by any user.
+        "used_in_testing": [
+            "test_my_python; python_version > '3.0'",
+            "test_new_python; python_version >= '5.1'",
+            "test_old_python; python_version < '2.7'",
+            "test_some_fake_package; sys_platform == 'fakeos'",
+            "test_some_linux_package; sys_platform == 'linux'",
+            "test_some_macos_package; sys_platform == 'osx'",
+            "test_some_package",
+            "test_specific_version == 1.2.3",
+        ],
+        "used_in_testing_too": [
+            "test_additional_package >= 4.2.0",
+            "test_deactivated_marker; python_version >= '4.2'",
+            "test_marker; python_version >= '1.2'",
+        ],
+    },
     entry_points={"console_scripts": ["komodoenv = komodoenv.__main__:main"]},
     use_scm_version={"relative_to": __file__, "write_to": "komodoenv/_version.py"},
 )

--- a/tests/scripts/test_install_extra.py
+++ b/tests/scripts/test_install_extra.py
@@ -1,0 +1,30 @@
+import pytest
+from pkg_resources import UnknownExtra
+from komodoenv.scripts.install_extra import get_requires_for_package
+
+
+def test_no_extra():
+    with pytest.raises(UnknownExtra):
+        get_requires_for_package("setuptools", "tests")
+
+
+def test_single_extra():
+    actual = get_requires_for_package("komodoenv", ["used_in_testing"])
+    assert actual == [
+        "test_some_package",
+        "test_specific_version==1.2.3",
+        "test_my_python",
+        "test_some_linux_package",
+    ]
+
+
+def test_multi_extra():
+    actual = get_requires_for_package("komodoenv", ["used_in_testing", "used_in_testing_too"])
+    assert actual == [
+        "test_some_package",
+        "test_specific_version==1.2.3",
+        "test_my_python",
+        "test_some_linux_package",
+        "test_additional_package>=4.2.0",
+        "test_marker",
+    ]


### PR DESCRIPTION
The Komodo integration unit testing that we run on Jenkins uses
komodoenv to set up an environment into which we can install testing
dependencies such as pytest. A strong requirement is that this komodoenv
doesn't actually install the given package's runtime requirements nor
the package itself.

That is, in case of _ecl_, we want the tests of _ecl_ to use the package
as found in the komodo release that we're testing, rather than the one
that could be potentially installed in komodoenv. We take care to only
`pip install -r test_requirements.txt`, and hope that this file doesn't
contain any runtime dependencies so that our tests don't pass
accidentally when we forget to add some important package from
`setup.py` into the komodo release.

The more modern and official way of handling test requirements is to add
`extras_require` which allows us to `pip install
webviz-config[testing]`, thereby installing not only the `webviz-config`
package but also all dependencies marked with `testing`.

It is currently not possible to ask `pip` to install _only_ these
extras. This `install_extra` script does allow this. The usage is as
follows, which will install _only_ the dependencies marked 'testing',
and not `webviz-config` nor its runtime dependencies:

```
python -m komodoenv.scripts.install_extra webviz-config testing
```