### PR TITLE
upgrade python versions in tests and workflow 

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -22,7 +22,7 @@ jobs:
         python-version: 3.8
     - name: Install Ubuntu Packages
       run: |
-        sudo apt-get -y install tcsh python3-venv python3.8-venv
+        sudo apt-get -y install tcsh
     - name: Install Python Packages
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -12,14 +12,14 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.6
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.6
+        python-version: 3.8
     - name: Install Ubuntu Packages
       run: |
         sudo apt-get -y install tcsh python3-venv python3.8-venv

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,19 +7,6 @@ from subprocess import check_output
 
 
 @pytest.fixture(scope="session")
-def python36_path():
-    """Locate Python 3.6 executable
-
-    RHEL7/8      : yum install python3-dev
-    Ubuntu 18.04 : apt-get install python3-{dev,venv}
-    """
-    exe = "/usr/bin/python3.6"
-    if not os.path.isfile(exe):
-        raise RuntimeError("Could not locate python3.6")
-    return exe
-
-
-@pytest.fixture(scope="session")
 def python38_path():
     """Locate Python 3.8 executable
 
@@ -38,7 +25,7 @@ def python38_path():
 
 
 @pytest.fixture(scope="session")
-def komodo_root(tmp_path_factory, python36_path, python38_path):
+def komodo_root(tmp_path_factory, python38_path):
     """Komodo mock environment"""
     # It takes forever to generate the virtualenvs. Let the developer set this
     # environment variable to reuse a previously-bootstrapped komodo root.
@@ -48,24 +35,24 @@ def komodo_root(tmp_path_factory, python36_path, python38_path):
     path = tmp_path_factory.mktemp("prog-res-komodo")
 
     # Install and configure pythons
-    _install(python36_path, path / "2030.01.00-py36", ["numpy==1.18.4"])
-    _install(python36_path, path / "2030.01.01-py36", ["numpy==1.19.1"])
+    _install(python38_path, path / "2030.01.00-py38", ["numpy==1.18.4"])
+    _install(python38_path, path / "2030.01.01-py38", ["numpy==1.19.1"])
     _install(python38_path, path / "2030.02.00-py38")
     _install(python38_path, path / "2030.03.00-py38-rhel9")
-    _install(python36_path, path / "bleeding-py36-rhel7")
+    _install(python38_path, path / "bleeding-py38-rhel7")
 
     for chain in (
-        ("2030.01", "2030.01-py3", "2030.01-py36", "2030.01.00-py36"),
+        ("2030.01", "2030.01-py3", "2030.01-py38", "2030.01.00-py38"),
         ("2030.02", "2030.02-py3", "2030.02-py38", "2030.02.00-py38"),
         ("2030.03", "2030.03-py3", "2030.03-py38", "2030.03.00-py38"),
-        # Stable points to py36, unspecified-rhel
-        ("stable", "stable-py3", "stable-py36", "2030.01-py36"),
-        # Testing points to py36, rhel7
-        ("testing", "testing-py3", "testing-py36", "2030.02-py36"),
+        # Stable points to py38, unspecified-rhel
+        ("stable", "stable-py3", "stable-py38", "2030.01-py38"),
+        # Testing points to py38, rhel7
+        ("testing", "testing-py3", "testing-py38", "2030.02-py38"),
         # Unstable refers to a future version of RHEL
         ("unstable", "unstable-py3", "unstable-py38", "2030.03-py38"),
-        # Bleeding points to py36, rhel7
-        ("bleeding", "bleeding-py3", "bleeding-py36"),
+        # Bleeding points to py38, rhel7
+        ("bleeding", "bleeding-py3", "bleeding-py38"),
     ):
         for src, dst in zip(chain[:-1], chain[1:]):
             (path / src).symlink_to(dst)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -33,7 +33,7 @@ def test_init_bash(komodo_root, tmp_path):
         "--root",
         str(komodo_root),
         "--release",
-        "2030.01.00-py36",
+        "2030.01.00-py38",
         str(tmp_path / "kenv"),
     )
 
@@ -54,7 +54,7 @@ def test_init_csh(komodo_root, tmp_path):
         "--root",
         str(komodo_root),
         "--release",
-        "2030.01.00-py36",
+        "2030.01.00-py38",
         str(tmp_path / "kenv"),
     )
 
@@ -75,7 +75,7 @@ def test_update(request, komodo_root, tmp_path):
         "--root",
         str(komodo_root),
         "--release",
-        "2030.01-py36",
+        "2030.01-py38",
         str(tmp_path / "kenv"),
     )
 
@@ -83,12 +83,12 @@ def test_update(request, komodo_root, tmp_path):
     check_output([str(tmp_path / "kenv/root/bin/komodoenv-update"), "--check"])
 
     # Update to 2030.01.01
-    (komodo_root / "2030.01-py36").unlink()
-    (komodo_root / "2030.01-py36").symlink_to("2030.01.01-py36")
+    (komodo_root / "2030.01-py38").unlink()
+    (komodo_root / "2030.01-py38").symlink_to("2030.01.01-py38")
 
     def revert():
-        (komodo_root / "2030.01-py36").unlink()
-        (komodo_root / "2030.01-py36").symlink_to("2030.01.00-py36")
+        (komodo_root / "2030.01-py38").unlink()
+        (komodo_root / "2030.01-py38").symlink_to("2030.01.00-py38")
 
     request.addfinalizer(revert)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,16 +5,16 @@ import komodoenv.__main__ as main
 @pytest.mark.parametrize(
     "expect,track_name,name",
     [
-        # Bleeding is py36, rhel7
-        ("bleeding-py36-rhel7", "bleeding-py36", "bleeding"),
-        ("bleeding-py36-rhel7", "bleeding-py36", "bleeding-py3"),
-        ("bleeding-py36-rhel7", "bleeding-py36", "bleeding-py36"),
-        # Stable is py36, unspecified rhel
-        ("2030.01.00-py36", "stable-py36", "stable"),
-        ("2030.01.00-py36", "stable-py36", "stable-py3"),
-        ("2030.01.00-py36", "stable-py36", "stable-py36"),
-        ("2030.01.00-py36", "stable-py36", "2030.01"),
-        ("2030.01.00-py36", "stable-py36", "2030.01.00-py36"),
+        # Bleeding is py38, rhel7
+        ("bleeding-py38-rhel7", "bleeding-py38", "bleeding"),
+        ("bleeding-py38-rhel7", "bleeding-py38", "bleeding-py3"),
+        ("bleeding-py38-rhel7", "bleeding-py38", "bleeding-py38"),
+        # Stable is py38, unspecified rhel
+        ("2030.01.00-py38", "stable-py38", "stable"),
+        ("2030.01.00-py38", "stable-py38", "stable-py3"),
+        ("2030.01.00-py38", "stable-py38", "stable-py38"),
+        ("2030.01.00-py38", "stable-py38", "2030.01"),
+        ("2030.01.00-py38", "stable-py38", "2030.01.00-py38"),
     ],
 )
 def test_resolve_simple(komodo_root, track_name, name, expect):
@@ -37,7 +37,7 @@ def test_resolve_simple(komodo_root, track_name, name, expect):
         "2030.03.00-py38",
         "2030.03.00-py38-rhel9",
         # Singular release
-        "2030.01.01-py36"
+        "2030.01.01-py38",
     ],
 )
 def test_resolve_fail(komodo_root, name):
@@ -51,26 +51,26 @@ def test_resolve_fail_singular(komodo_root):
     the user and exit.
     """
     with pytest.raises(SystemExit) as exc:
-        main.resolve_release(komodo_root, "2030.01.01-py36")
+        main.resolve_release(komodo_root, "2030.01.01-py38")
     assert "--no-update" in str(exc.value)
 
 
 @pytest.mark.parametrize(
     "expect,name",
     [
-        # Bleeding is py36, rhel7
-        ("bleeding-py36-rhel7", "bleeding"),
-        ("bleeding-py36-rhel7", "bleeding-py3"),
-        ("bleeding-py36-rhel7", "bleeding-py36"),
-        # Stable is py36, unspecified rhel
-        ("2030.01.00-py36", "stable"),
-        ("2030.01.00-py36", "stable-py3"),
-        ("2030.01.00-py36", "stable-py36"),
-        ("2030.01.00-py36", "2030.01"),
-        ("2030.01.00-py36", "2030.01.00-py36"),
+        # Bleeding is py38, rhel7
+        ("bleeding-py38-rhel7", "bleeding"),
+        ("bleeding-py38-rhel7", "bleeding-py3"),
+        ("bleeding-py38-rhel7", "bleeding-py38"),
+        # Stable is py38, unspecified rhel
+        ("2030.01.00-py38", "stable"),
+        ("2030.01.00-py38", "stable-py3"),
+        ("2030.01.00-py38", "stable-py38"),
+        ("2030.01.00-py38", "2030.01"),
+        ("2030.01.00-py38", "2030.01.00-py38"),
         # Singular release
-        ("2030.01.01-py36", "2030.01.01-py36"),
-    ]
+        ("2030.01.01-py38", "2030.01.01-py38"),
+    ],
 )
 def test_resolve_no_update(komodo_root, expect, name):
     release, tracked = main.resolve_release(komodo_root, name, no_update=True)


### PR DESCRIPTION
Resolves #48 
Upgrade ubuntu and python versions in the workflow and perform corresponding changes in tests.