### PR TITLE
Allow third coordinate in release name

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,15 +39,17 @@ def komodo_root(tmp_path_factory, python311_path):
     _install(python311_path, path / "2030.02.00-py311")
     _install(python311_path, path / "2030.03.00-py311-rhel9")
     _install(python311_path, path / f"bleeding-py311-rhel{rhel_version()}")
+    _install(python311_path, path / f"2025.04.01-py311-rhel{rhel_version()}-numpy1")
 
     for chain in (
         ("2030.01", "2030.01-py3", "2030.01-py311", "2030.01.00-py311"),
         ("2030.02", "2030.02-py3", "2030.02-py311", "2030.02.00-py311"),
         ("2030.03", "2030.03-py3", "2030.03-py311", "2030.03.00-py311"),
+        ("2025.04", "2025.04-py3", "2025.04-py311", "2025.04.01-py311"),
         # Stable points to py311, unspecified-rhel
         ("stable", "stable-py3", "stable-py311", "2030.01-py311"),
-        # Testing points to py311, rhel8
-        ("testing", "testing-py3", "testing-py311", "2030.02-py311"),
+        # Testing points to py311, rhel8, numpy1
+        ("testing", "testing-py3", "testing-py311", "2025.04-py311"),
         # Bleeding points to py311, rhel8
         ("bleeding", "bleeding-py3", "bleeding-py311"),
     ):
@@ -76,13 +78,25 @@ def _install(python: str, path: Path, packages=None):
         f"setenv KOMODO_RELEASE {path.name}\nsetenv PATH {path}/root/bin:$PATH\n",
     )
 
-    # Create a redirect script if path ends in '-rhelX'
-    match = re.match("^(.+)-rhel[0-9]+$", path.name)
+    # Create a redirect script if path contains '-rhelX'
+    match = re.match("^(.+)-rhel[0-9]", path.name)
+
+    optional_custom_coordinate = path.name.split("-")[-1]
+    custom_coordinate = ""
+    if optional_custom_coordinate and not any(
+        optional_custom_coordinate.startswith(substring) for substring in ["py", "rhel"]
+    ):
+        custom_coordinate = optional_custom_coordinate
+
     if match is not None:
         p = path.parent / match[1]
         p.mkdir()
-        (p / "enable").write_text(f"source {path}/enable")
-        (p / "enable.csh").write_text(f"source {path}/enable.csh")
+        (p / "enable").write_text(
+            f'CUSTOM_COORDINATE="{custom_coordinate}"\nsource {path}/enable'
+        )
+        (p / "enable.csh").write_text(
+            f'set CUSTOM_COORDINATE="{custom_coordinate}"\nsource {path}/enable.csh'
+        )
 
     # Install additional packages
     if packages:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,11 +14,17 @@ def generate_test_params_simple(rhel_version):
         (f"bleeding-py311-rhel{rhel_version}", "bleeding-py311", "bleeding"),
         (f"bleeding-py311-rhel{rhel_version}", "bleeding-py311", "bleeding-py3"),
         (f"bleeding-py311-rhel{rhel_version}", "bleeding-py311", "bleeding-py311"),
+        (f"2025.04.01-py311-rhel{rhel_version}-numpy1", "testing-py311", "testing"),
+        (
+            f"2025.04.01-py311-rhel{rhel_version}-numpy1",
+            "testing-py311",
+            "testing-py311",
+        ),
     ]
 
 
 @pytest.mark.parametrize(
-    "expect, track_name,name",
+    "expect, track_name, name",
     generate_test_params_simple(rhel_version()),
 )
 def test_resolve_simple(komodo_root, track_name, name, expect):
@@ -65,6 +71,10 @@ def generate_test_params_no_update(rhel_version):
         (f"bleeding-py311-rhel{rhel_version}", "bleeding"),
         (f"bleeding-py311-rhel{rhel_version}", "bleeding-py3"),
         (f"bleeding-py311-rhel{rhel_version}", "bleeding-py311"),
+        (f"2025.04.01-py311-rhel{rhel_version}-numpy1", "2025.04"),
+        (f"2025.04.01-py311-rhel{rhel_version}-numpy1", "2025.04-py3"),
+        (f"2025.04.01-py311-rhel{rhel_version}-numpy1", "2025.04-py311"),
+        (f"2025.04.01-py311-rhel{rhel_version}-numpy1", "2025.04.01-py311"),
     ]
 
 


### PR DESCRIPTION
**Issue**
Resolves #95 

Pick up optional custom coordinates from the enable-scripts.
They have similar syntax and contain the necessary information to find the correct release.

Tested on the `numpy` release after changing the `komodoenv.conf` file accordingly.

## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See
    [Ground Rules](https://github.com/equinor/komodoenv/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/komodoenv/blob/main/CONTRIBUTING.md).
