### PR TITLE
Fix komodoenv bleeding tracking

### DIFF
--- a/src/komodoenv/__main__.py
+++ b/src/komodoenv/__main__.py
@@ -54,7 +54,7 @@ def distro_suffix():
     return f"-rhel{distro.major_version()}"
 
 
-def resolve_release(  # noqa: C901
+def resolve_release(
     *,
     root: Path,
     name: str,
@@ -95,18 +95,15 @@ def resolve_release(  # noqa: C901
     distribution_suffix = distro_suffix()
 
     for mode in "stable", "testing", "bleeding":
-        for rhver in "", distribution_suffix:
-            track = root / (mode + pyver)
-            dir_ = (root / (mode + pyver + rhver)).resolve()
+        track = root / (mode + pyver)
+        dir_ = get_tracked_release(
+            (root / (mode + pyver)).resolve(), distribution_suffix
+        )
 
-            if not (dir_ / "root").is_dir():
-                dir_ = (root / (mode + pyver)).resolve()
-            dir_ = get_tracked_release(dir_, distribution_suffix)
-
-            if (dir_ / "root").is_dir():
-                symlink = dir_.resolve()
-                if symlink.name == actual_path.name:
-                    return symlink, track
+        if (dir_ / "root").is_dir():
+            symlink = dir_.resolve()
+            if symlink.name == actual_path.name:
+                return symlink, track
 
     sys.exit(
         "Could not automatically detect an appropriate Komodo release to track (one of: stable, testing, bleeding).\n"


### PR DESCRIPTION
**Issue**
Resolves https://github.com/equinor/komodo-releases/issues/7334

This branch is testable onprem, and produce a komodoenv that can be updated.
It's not a perfect test though.

```
(mystable + 2025.04.05-py311-rhel8) [andrli@st-lintgx0275 komodoenv]$ komodoenv --root /prog/res/komodo --track bleeding test-me-now2
Info: If you encounter issues with the Jupyter environment or the 'rips' package, try running 'komodoenv-update' or sourcing the komodoenv again.

Warning: Tracking a bleeding release of komodo. It changes every day. You will need to recreate komodoenv in order to use new executables in komodo.

        venv    using /private/andrli/project/mystable/root/bin/python
      create    komodoenv.conf
      create    /private/andrli/project/komodoenv/test-me-now2/root/lib/python3.11/site-packages/zzz_komodo.pth
      create    root/bin/komodoenv-update
         run    root/bin/komodoenv-update
     install    pip
      remove    root/shims/komodoenv

Komodoenv has successfully been generated. You can now pip-install software.

    $ source /private/andrli/project/komodoenv/test-me-now2/enable
```

## Pre review checklist

- [ ] Read through the code changes carefully after finishing work
- [ ] Make sure tests pass locally (after every commit!)
- [ ] Prepare changes in small commits for more convenient review (optional)
- [ ] PR title captures the intent of the changes, and is fitting for release notes.
- [ ] Updated documentation
- [ ] Ensured that unit tests are added for all new behavior (See
    [Ground Rules](https://github.com/equinor/komodoenv/blob/main/CONTRIBUTING.md#ground-rules)),
    and changes to existing code have good test coverage.

## Pre merge checklist
- [ ] Added appropriate release note label
- [ ] Commit history is consistent and clean, in line with the [contribution guidelines](https://github.com/equinor/komodoenv/blob/main/CONTRIBUTING.md).
