### PR TITLE
Pin actions to hashes

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -11,9 +11,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.12
       - name: Install dependencies

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,8 +17,8 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "${{ matrix.python-version }}"
       - name: Install Ubuntu Packages


### PR DESCRIPTION
The following actions were pinned:
- actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2 (https://github.com/actions/checkout/releases/tag/v6.0.2)
- actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0 (https://github.com/actions/setup-python/releases/tag/v6.2.0)